### PR TITLE
feat: add aarch64 support and refactor binary download

### DIFF
--- a/src/AstMetricsProxy.php
+++ b/src/AstMetricsProxy.php
@@ -3,10 +3,11 @@
 namespace Halleck45\AstMetrics;
 
 use Exception;
+use RuntimeException;
 
 /**
  * This class is a proxy for the AST Metrics binary, for PHP
- * 
+ *
  * It downloads the binary from the latest release on GitHub, if it's not already downloaded
  * It then runs the binary with the provided arguments
  */
@@ -14,8 +15,13 @@ class AstMetricsProxy {
 
     private $binaryPath;
 
+    private static $archAliases = [
+        'aarch64' => 'arm64',
+        'x64'     => 'x86_64',
+    ];
+
     public function __construct() {
-        $this->binaryPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR. 'ast-metrics';
+        $this->binaryPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ast-metrics';
     }
 
     public function run($arguments) {
@@ -29,20 +35,20 @@ class AstMetricsProxy {
 
     private function buildCommand($arguments) {
         $command = "$this->binaryPath " . implode(' ', $arguments);
-        $command = preg_replace('/\s+/', ' ', $command); // Replace multiple spaces with single space
-        $command = str_replace(' analyze', ' analyze --non-interactive ', $command); // Add --non-interactive flag
-        $command = str_replace(' a ', ' a  --non-interactive ', $command); // Add --non-interactive flag
-        $command = preg_replace('/ a$/', ' a --non-interactive', $command); // Add --non-interactive flag
-
-        return $command;
+        $command = preg_replace('/\s+/', ' ', $command);
+        $command = str_replace([' analyze', ' a '], [' analyze --non-interactive ', ' a --non-interactive '], $command);
+        return preg_replace('/ a$/', ' a --non-interactive', $command);
     }
 
     private function executeCommand($command) {
         exec($command, $output, $returnCode);
 
         if ($returnCode !== 0) {
-            $exception = new Exception("AST Metrics execution failed with code: $returnCode" . PHP_EOL . "Output:" . PHP_EOL . implode(PHP_EOL, $output));
-            throw $exception;
+            throw new RuntimeException(
+                "AST Metrics execution failed with code: $returnCode" . PHP_EOL .
+                "Output:" . PHP_EOL .
+                implode(PHP_EOL, $output)
+            );
         }
 
         echo implode(PHP_EOL, $output);
@@ -52,53 +58,47 @@ class AstMetricsProxy {
         return file_exists($this->binaryPath) && is_executable($this->binaryPath);
     }
 
+    /**
+     * @throws Exception
+     */
     private function downloadBinary() {
-
         echo "First time running AST Metrics, downloading binary..." . PHP_EOL;
 
-        // Define download URLs based on platform and architecture
-        $version = $this->getLatestRelease();
-        $downloads = [
-            'Linux' => [
-            'i386' => "https://github.com/Halleck45/ast-metrics/releases/download/$version/ast-metrics_Linux_i386",
-            'x86_64' => "https://github.com/Halleck45/ast-metrics/releases/download/$version/ast-metrics_Linux_x86_64",
-            'arm64' => "https://github.com/Halleck45/ast-metrics/releases/download/$version/ast-metrics_Linux_arm64",
-            ],
-            'Darwin' => [ // macOS
-            'x86_64' => "https://github.com/Halleck45/ast-metrics/releases/download/$version/ast-metrics_Darwin_x86_64",
-            'arm64' => "https://github.com/Halleck45/ast-metrics/releases/download/$version/ast-metrics_Darwin_arm64",
-            ],
-            'Windows' => [
-            'i386' => "https://github.com/Halleck45/ast-metrics/releases/download/$version/ast-metrics_Windows_i386.exe",
-            'x86_64' => "https://github.com/Halleck45/ast-metrics/releases/download/$version/ast-metrics_Windows_x86_64.exe",
-            'arm64' => "https://github.com/Halleck45/ast-metrics/releases/download/$version/ast-metrics_Windows_arm64.exe",
-            ],
-        ];
-        
-        // Get current platform and architecture
         $platform = php_uname('s');
-        $arch = php_uname('m');
-        
-        // Determine download URL based on platform and architecture
-        $downloadUrl = null;
-        if (!isset($downloads[$platform][$arch])) {
-            throw new Exception("Unsupported platform or architecture: $platform - $arch");
-        }
+        $arch     = $this->normalizeArch(php_uname('m'));
+        $version  = $this->getLatestRelease();
+        $url      = $this->resolveDownloadUrl($platform, $arch, $version);
 
-        $downloadUrl = $downloads[$platform][$arch];
-
-        $content = file_get_contents($downloadUrl);
+        $content = file_get_contents($url);
         if ($content === false) {
-            throw new Exception("Failed to download AST Metrics binary");
+            throw new Exception("Failed to download AST Metrics binary from: $url");
         }
 
-        // Save the binary
         file_put_contents($this->binaryPath, $content);
-        
-        // Set permissions (assuming executable extension for Linux/macOS)
+
         if (strpos($platform, 'Windows') === false) {
             chmod($this->binaryPath, 0755);
         }
+    }
+
+    private function normalizeArch($arch) {
+        return self::$archAliases[$arch] ?? $arch;
+    }
+
+    private function resolveDownloadUrl($platform, $arch, $version): string
+    {
+        $ext = strpos($platform, 'Windows') !== false ? '.exe' : '';
+        $downloads = [
+            'Linux'   => ['i386', 'x86_64', 'arm64'],
+            'Darwin'  => ['x86_64', 'arm64'],
+            'Windows' => ['i386', 'x86_64', 'arm64'],
+        ];
+
+        if (!isset($downloads[$platform]) || !in_array($arch, $downloads[$platform], true)) {
+            throw new RuntimeException("Unsupported platform or architecture: $platform / $arch");
+        }
+
+        return "https://github.com/Halleck45/ast-metrics/releases/download/$version/ast-metrics_{$platform}_{$arch}{$ext}";
     }
 
     private function getLatestRelease() {
@@ -108,12 +108,15 @@ class AstMetricsProxy {
             ]
         ]);
 
-        $latestRelease = json_decode(file_get_contents('https://api.github.com/repos/Halleck45/ast-metrics/releases/latest', false, $context), true);
+        $latestRelease = json_decode(
+            file_get_contents('https://api.github.com/repos/Halleck45/ast-metrics/releases/latest', false, $context),
+            true
+        );
+
         if ($latestRelease === null) {
-            throw new Exception("Failed to get latest release information");
+            throw new RuntimeException("Failed to get latest release information");
         }
 
         return $latestRelease['tag_name'];
     }
-
 }


### PR DESCRIPTION
Alpine Linux reports architecture as aarch64 via php_uname('m'), but GitHub release binaries are named arm64 (same CPU, different naming convention). The old code had a static URL map with no aarch64 entry, causing an "Unsupported architecture" exception on Alpine.

Changes:

normalizeArch() — translates OS arch names to binary names (aarch64 → arm64) before URL resolution. Extensible: add any new alias in one place.
resolveDownloadUrl() — builds the URL dynamically from platform/arch/version, removing the duplicated URL strings that existed for every platform × arch combination.